### PR TITLE
RENO-1153-update-dgx-react-footer-to-0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v0.3.14
+- Updating @nypl/dgx-react-footer to 0.5.4.
+
 ### v0.3.13
 - Updating @nypl/dgx-header-component to 2.6.0.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NYPL Blogs app
 
 ## Version
-> v0.3.13
+> v0.3.14
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-blogs",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "NYPL Blogs React App",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@nypl/dgx-header-component": "2.6.0",
-    "@nypl/dgx-react-footer": "0.5.2",
+    "@nypl/dgx-react-footer": "0.5.4",
     "alt": "0.18.2",
     "alt-utils": "1.0.0",
     "axios": "0.9.1",


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1153)

**This PR does the following:**

- Updates dgx-react-footer to v0.5.4
- The footer update removes the Kievit font, Tumbler icon, and adds [system-font-css](https://github.com/jonathantneal/system-font-css) according to this [migration guide](https://docs.google.com/document/d/1gErDfbmTuKvSUkmfFnhRh9BAF1CCqUl66koTAtOZmdU/edit#)